### PR TITLE
Paidy Forex Proxy Coding Exercises

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,19 @@ TAGS
 tests.iml
 # Auto-copied by sbt-microsites
 docs/src/main/tut/contributing.md
+
+# Bloop
+.bsp
+
+# VS Code
+.vscode/
+
+# Metals
+.bloop/
+.metals/
+metals.sbt
+
+# IDEA
+.idea
+.idea_modules
+/.worksheet/

--- a/forex-mtl/README.md
+++ b/forex-mtl/README.md
@@ -1,0 +1,76 @@
+# Forex Proxy Service
+
+A local proxy service for fetching currency exchange rates, built with Scala.This service acts as a middleware for the One-Frame API, providing caching and freshness guarantees to overcome upstream limitations.
+
+## 🚀 Quick Start
+
+### 1. Prerequisites
+- **Java 11+**
+- **sbt** (Scala Build Tool)
+- **Docker** (to run the One-Frame upstream service)
+
+### 2. Run the Upstream Service (One-Frame)
+The application requires the One-Frame API to be running locally.
+```bash
+docker pull paidyinc/one-frame
+docker run -p 8080:8080 paidyinc/one-frame
+```
+
+### 3. Build and Run the Application
+Navigate to the `forex-mtl` directory and start the server:
+```bash
+cd forex-mtl
+sbt run
+```
+The server starts on `http://localhost:3000`by default. You can change the port in `application.conf`.
+
+## 🛠 Usage
+
+### Get Exchange Rate
+Fetch the current exchange rate between two supported currencies.
+
+**Endpoint:** `GET /rates`
+
+**Parameters:**
+- `from`: Source currency code (e.g., USD)
+- `to`: Target currency code (e.g., JPY)
+
+**Example Request:**
+```bash
+curl "http://localhost:3000/rates?from=USD&to=JPY"
+``` 
+
+**Example Response:**
+```json
+{
+  "from": "USD",
+  "to": "JPY",
+  "bid": 0.61,
+  "ask": 0.82,
+  "price": 0.71,
+  "timestamp": "2023-10-27T10:00:00Z"
+}
+```
+
+## 🧪 Testing
+Run the unit tests to verify caching and rate retrieval logic:
+```bash
+sbt test
+```
+## ⚙️ Configuration
+Settings for the HTTP server, cache TTL, and One-Frame API can be found in:
+`src/main/resources/application.conf`
+
+## 🔍 Test the Service via Curl
+Run curl command to test the service:
+```bash
+curl "http://localhost:{your-port}/rates?from=USD&to=JPY"
+```
+
+## 💡 Key Features
+- **Intelligent Caching**: Implements an in-memory cache with a 5-minute TTL.
+- **API Limit Management**: Designed to support 10,000+ requests/day by minimizing calls to the One-Frame API (which has a 1,000 request/day limit).
+- **Rate Freshness**: Automatically refreshes rates older than 5 minutes to ensure data accuracy.
+- **Descriptive Errors**: Provides clear feedback for invalid currencies or upstream failures.
+
+

--- a/forex-mtl/build.sbt
+++ b/forex-mtl/build.sbt
@@ -3,7 +3,7 @@ import Dependencies._
 name := "forex"
 version := "1.0.1"
 
-scalaVersion := "2.13.12"
+scalaVersion := "2.13.14"
 scalacOptions ++= Seq(
   "-deprecation", // Emit warning and location for usages of deprecated APIs.
   "-encoding",
@@ -54,6 +54,7 @@ libraryDependencies ++= Seq(
   Libraries.cats,
   Libraries.catsEffect,
   Libraries.fs2,
+  Libraries.http4sClient,
   Libraries.http4sDsl,
   Libraries.http4sServer,
   Libraries.http4sCirce,
@@ -63,7 +64,7 @@ libraryDependencies ++= Seq(
   Libraries.circeParser,
   Libraries.pureConfig,
   Libraries.logback,
-  Libraries.scalaTest      % Test,
-  Libraries.scalaCheck     % Test,
+  Libraries.scalaTest % Test,
+  Libraries.scalaCheck % Test,
   Libraries.catsScalaCheck % Test
 )

--- a/forex-mtl/project/Dependencies.scala
+++ b/forex-mtl/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
     val circe      = "0.14.2"
     val pureConfig = "0.17.4"
 
-    val kindProjector  = "0.13.2"
+    val kindProjector  = "0.13.3"
     val logback        = "1.2.3"
     val scalaCheck     = "1.15.3"
     val scalaTest      = "3.2.7"
@@ -28,6 +28,7 @@ object Dependencies {
     lazy val http4sDsl       = http4s("http4s-dsl")
     lazy val http4sServer    = http4s("http4s-blaze-server")
     lazy val http4sCirce     = http4s("http4s-circe")
+    lazy val http4sClient    = http4s("http4s-blaze-client")
     lazy val circeCore       = circe("circe-core")
     lazy val circeGeneric    = circe("circe-generic")
     lazy val circeGenericExt = circe("circe-generic-extras")

--- a/forex-mtl/project/build.properties
+++ b/forex-mtl/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.10.0

--- a/forex-mtl/src/main/resources/application.conf
+++ b/forex-mtl/src/main/resources/application.conf
@@ -7,6 +7,7 @@ app {
     one-frame {
       base-url = "http://localhost:8080"
       token = "10dc303535874aeccc86a8251e6992f5"
+      ttl = 5 minutes
     }
 }
 

--- a/forex-mtl/src/main/resources/application.conf
+++ b/forex-mtl/src/main/resources/application.conf
@@ -1,8 +1,12 @@
 app {
   http {
     host = "0.0.0.0"
-    port = 8080
+    port = 3000
     timeout = 40 seconds
   }
+    one-frame {
+      base-url = "http://localhost:8080"
+      token = "10dc303535874aeccc86a8251e6992f5"
+    }
 }
 

--- a/forex-mtl/src/main/scala/forex/Main.scala
+++ b/forex-mtl/src/main/scala/forex/Main.scala
@@ -5,12 +5,12 @@ import cats.effect._
 import forex.config._
 import fs2.Stream
 import org.http4s.blaze.server.BlazeServerBuilder
+import org.http4s.blaze.client.BlazeClientBuilder
 
 object Main extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] =
-    new Application[IO].stream(executionContext).compile.drain.as(ExitCode.Success)
-
+    new Application[IO].stream(ExecutionContext.global).compile.drain.as(ExitCode.Success)
 }
 
 class Application[F[_]: ConcurrentEffect: Timer] {
@@ -18,9 +18,10 @@ class Application[F[_]: ConcurrentEffect: Timer] {
   def stream(ec: ExecutionContext): Stream[F, Unit] =
     for {
       config <- Config.stream("app")
-      module = new Module[F](config)
+      client <- Stream.resource(BlazeClientBuilder[F](ec).resource)
+      module = new Module[F](config, client)
       _ <- BlazeServerBuilder[F](ec)
-            .bindHttp(config.http.port, config.http.host)
+            .bindHttp(config.http.port, "0.0.0.0")
             .withHttpApp(module.httpApp)
             .serve
     } yield ()

--- a/forex-mtl/src/main/scala/forex/Module.scala
+++ b/forex-mtl/src/main/scala/forex/Module.scala
@@ -8,10 +8,11 @@ import forex.programs._
 import org.http4s._
 import org.http4s.implicits._
 import org.http4s.server.middleware.{ AutoSlash, Timeout }
+import org.http4s.client.Client
 
-class Module[F[_]: Concurrent: Timer](config: ApplicationConfig) {
+class Module[F[_]: Concurrent: Timer](config: ApplicationConfig, client: Client[F]) {
 
-  private val ratesService: RatesService[F] = RatesServices.dummy[F]
+  private val ratesService: RatesService[F] = RatesServices.live[F](config, client)
 
   private val ratesProgram: RatesProgram[F] = RatesProgram[F](ratesService)
 

--- a/forex-mtl/src/main/scala/forex/Module.scala
+++ b/forex-mtl/src/main/scala/forex/Module.scala
@@ -1,25 +1,34 @@
 package forex
 
-import cats.effect.{ Concurrent, Timer }
+import cats.effect.{Concurrent, Timer}
 import forex.config.ApplicationConfig
 import forex.http.rates.RatesHttpRoutes
 import forex.services._
+import forex.services.cache.CacheService
 import forex.programs._
 import org.http4s._
 import org.http4s.implicits._
-import org.http4s.server.middleware.{ AutoSlash, Timeout }
+import org.http4s.server.middleware.{AutoSlash, Timeout}
 import org.http4s.client.Client
+import cats.effect.IO
 
-class Module[F[_]: Concurrent: Timer](config: ApplicationConfig, client: Client[F]) {
+class Module[F[_]: Concurrent: Timer](
+    config: ApplicationConfig,
+    client: Client[F]
+) {
 
-  private val ratesService: RatesService[F] = RatesServices.live[F](config, client)
+  private val ratesService: RatesService[F] = {
+    // cache service instantiated in IO context
+    val cache = CacheService[IO].unsafeRunSync().asInstanceOf[CacheService[F]]
+    RatesServices.live[F](config, client, cache)
+  }
 
   private val ratesProgram: RatesProgram[F] = RatesProgram[F](ratesService)
-
-  private val ratesHttpRoutes: HttpRoutes[F] = new RatesHttpRoutes[F](ratesProgram).routes
+  private val ratesHttpRoutes: HttpRoutes[F] =
+    new RatesHttpRoutes[F](ratesProgram).routes
 
   type PartialMiddleware = HttpRoutes[F] => HttpRoutes[F]
-  type TotalMiddleware   = HttpApp[F] => HttpApp[F]
+  type TotalMiddleware = HttpApp[F] => HttpApp[F]
 
   private val routesMiddleware: PartialMiddleware = {
     { http: HttpRoutes[F] =>

--- a/forex-mtl/src/main/scala/forex/config/ApplicationConfig.scala
+++ b/forex-mtl/src/main/scala/forex/config/ApplicationConfig.scala
@@ -4,10 +4,16 @@ import scala.concurrent.duration.FiniteDuration
 
 case class ApplicationConfig(
     http: HttpConfig,
+    oneFrame: OneFrameConfig
 )
 
 case class HttpConfig(
     host: String,
     port: Int,
     timeout: FiniteDuration
+)
+
+case class OneFrameConfig(
+    baseUrl: String,
+    token: String
 )

--- a/forex-mtl/src/main/scala/forex/config/ApplicationConfig.scala
+++ b/forex-mtl/src/main/scala/forex/config/ApplicationConfig.scala
@@ -15,5 +15,6 @@ case class HttpConfig(
 
 case class OneFrameConfig(
     baseUrl: String,
-    token: String
+    token: String,
+    ttl: FiniteDuration
 )

--- a/forex-mtl/src/main/scala/forex/domain/Rate.scala
+++ b/forex-mtl/src/main/scala/forex/domain/Rate.scala
@@ -3,6 +3,8 @@ package forex.domain
 case class Rate(
     pair: Rate.Pair,
     price: Price,
+    bid: Price,
+    ask: Price,
     timestamp: Timestamp
 )
 

--- a/forex-mtl/src/main/scala/forex/http/rates/Converters.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/Converters.scala
@@ -5,6 +5,7 @@ import forex.domain._
 object Converters {
   import Protocol._
 
+  // Response body for GET /rates?from={currencyPair}&to={currencyPair}
   private[rates] implicit class GetApiResponseOps(val rate: Rate) extends AnyVal {
     def asGetApiResponse: GetApiResponse =
       GetApiResponse(
@@ -13,6 +14,19 @@ object Converters {
         price = rate.price,
         bid = rate.bid,
         ask = rate.ask,
+        timestamp = rate.timestamp
+      )
+  }
+
+  // Response body for POST /rates
+  private[rates] implicit class PostApiResponseOps(val rate: Rate) extends AnyVal {
+    def asPostApiResponse(amount: BigDecimal): PostApiResponse =
+      PostApiResponse(
+        from = rate.pair.from,
+        to = rate.pair.to,
+        amount = amount,
+        exchangeRate = rate.price,
+        convertedAmount = amount * rate.price.value,
         timestamp = rate.timestamp
       )
   }

--- a/forex-mtl/src/main/scala/forex/http/rates/Converters.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/Converters.scala
@@ -11,6 +11,8 @@ object Converters {
         from = rate.pair.from,
         to = rate.pair.to,
         price = rate.price,
+        bid = rate.bid,
+        ask = rate.ask,
         timestamp = rate.timestamp
       )
   }

--- a/forex-mtl/src/main/scala/forex/http/rates/Protocol.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/Protocol.scala
@@ -83,11 +83,7 @@ object Protocol {
           errors += s"Field 'amount' must be a positive number"
         }
         
-        // Optional: Validate amount is not zero
-        // if (request.amount == 0) {
-        //   errors += "Field 'amount' must be greater than zero"
-        // }
-        
+        // checks if there are any errors in the list
         if (errors.nonEmpty) {
           Left(errors.mkString("; "))
         } else {

--- a/forex-mtl/src/main/scala/forex/http/rates/Protocol.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/Protocol.scala
@@ -10,7 +10,8 @@ import io.circe.generic.extras.semiauto.deriveConfiguredEncoder
 
 object Protocol {
 
-  implicit val configuration: Configuration = Configuration.default.withSnakeCaseMemberNames
+  implicit val configuration: Configuration =
+    Configuration.default.withSnakeCaseMemberNames
 
   final case class GetApiRequest(
       from: Currency,
@@ -21,6 +22,8 @@ object Protocol {
       from: Currency,
       to: Currency,
       price: Price,
+      bid: Price,
+      ask: Price,
       timestamp: Timestamp
   )
 

--- a/forex-mtl/src/main/scala/forex/http/rates/Protocol.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/Protocol.scala
@@ -47,6 +47,10 @@ object Protocol {
       convertedAmount: BigDecimal,
       timestamp: Timestamp
   )
+  // Response body for errors
+  final case class ErrorResponse(
+      message: String
+  )
 
   implicit val currencyEncoder: Encoder[Currency] =
     Encoder.instance[Currency] { show.show _ andThen Json.fromString }
@@ -71,8 +75,30 @@ object Protocol {
 
   implicit val postRequestDecoder: Decoder[PostApiRequest] =
     deriveConfiguredDecoder[PostApiRequest]
+      .emap { request =>
+        val errors = scala.collection.mutable.ListBuffer[String]()
+        
+        // Validate amount is not negative
+        if (request.amount < 0) {
+          errors += s"Field 'amount' must be a positive number"
+        }
+        
+        // Optional: Validate amount is not zero
+        // if (request.amount == 0) {
+        //   errors += "Field 'amount' must be greater than zero"
+        // }
+        
+        if (errors.nonEmpty) {
+          Left(errors.mkString("; "))
+        } else {
+          Right(request)
+        }
+      }
 
   implicit val postResponseEncoder: Encoder[PostApiResponse] =
     deriveConfiguredEncoder[PostApiResponse]
+
+  implicit val errorResponseEncoder: Encoder[ErrorResponse] =
+    deriveConfiguredEncoder[ErrorResponse]
 
 }

--- a/forex-mtl/src/main/scala/forex/http/rates/Protocol.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/Protocol.scala
@@ -6,18 +6,22 @@ import forex.domain.Rate.Pair
 import forex.domain._
 import io.circe._
 import io.circe.generic.extras.Configuration
-import io.circe.generic.extras.semiauto.deriveConfiguredEncoder
+import io.circe.generic.extras.semiauto.{
+  deriveConfiguredDecoder,
+  deriveConfiguredEncoder
+}
 
 object Protocol {
 
   implicit val configuration: Configuration =
-    Configuration.default.withSnakeCaseMemberNames
+    Configuration.default
 
+  // Request body for GET /rates
   final case class GetApiRequest(
       from: Currency,
       to: Currency
   )
-
+  // Response body for GET /rates
   final case class GetApiResponse(
       from: Currency,
       to: Currency,
@@ -27,8 +31,34 @@ object Protocol {
       timestamp: Timestamp
   )
 
+  // Request body for POST /rates
+  final case class PostApiRequest(
+      from: Currency,
+      to: Currency,
+      amount: BigDecimal
+  )
+
+  // Response body for POST /rates
+  final case class PostApiResponse(
+      from: Currency,
+      to: Currency,
+      amount: BigDecimal,
+      exchangeRate: Price,
+      convertedAmount: BigDecimal,
+      timestamp: Timestamp
+  )
+
   implicit val currencyEncoder: Encoder[Currency] =
     Encoder.instance[Currency] { show.show _ andThen Json.fromString }
+
+  implicit val currencyDecoder: Decoder[Currency] =
+    Decoder.decodeString.emap { s =>
+      scala.util
+        .Try(Currency.fromString(s))
+        .toEither
+        .left
+        .map(_ => s"Invalid currency: $s")
+    }
 
   implicit val pairEncoder: Encoder[Pair] =
     deriveConfiguredEncoder[Pair]
@@ -38,5 +68,11 @@ object Protocol {
 
   implicit val responseEncoder: Encoder[GetApiResponse] =
     deriveConfiguredEncoder[GetApiResponse]
+
+  implicit val postRequestDecoder: Decoder[PostApiRequest] =
+    deriveConfiguredDecoder[PostApiRequest]
+
+  implicit val postResponseEncoder: Encoder[PostApiResponse] =
+    deriveConfiguredEncoder[PostApiResponse]
 
 }

--- a/forex-mtl/src/main/scala/forex/http/rates/QueryParams.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/QueryParams.scala
@@ -2,12 +2,20 @@ package forex.http.rates
 
 import forex.domain.Currency
 import org.http4s.QueryParamDecoder
+import org.http4s.ParseFailure
 import org.http4s.dsl.impl.QueryParamDecoderMatcher
 
 object QueryParams {
 
   private[http] implicit val currencyQueryParam: QueryParamDecoder[Currency] =
-    QueryParamDecoder[String].map(Currency.fromString)
+    QueryParamDecoder[String].emap { s =>
+      scala.util.Try(Currency.fromString(s)).toEither.left.map { _ =>
+        ParseFailure(
+          s"Invalid currency: '$s'",
+          s"Currency must be one of: AUD, CAD, CHF, EUR, GBP, NZD, JPY, SGD, USD"
+        )
+      }
+    }
 
   object FromQueryParam extends QueryParamDecoderMatcher[Currency]("from")
   object ToQueryParam extends QueryParamDecoderMatcher[Currency]("to")

--- a/forex-mtl/src/main/scala/forex/http/rates/RatesHttpRoutes.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/RatesHttpRoutes.scala
@@ -9,7 +9,7 @@ import forex.programs.rates.{Protocol => RatesProgramProtocol}
 import org.http4s.HttpRoutes
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.Router
-import org.http4s.ParseFailure
+import org.http4s.{ParseFailure, MessageFailure}
 import io.circe.{DecodingFailure, CursorOp}
 
 class RatesHttpRoutes[F[_]: Sync](rates: RatesProgram[F]) extends Http4sDsl[F] {
@@ -101,20 +101,22 @@ class RatesHttpRoutes[F[_]: Sync](rates: RatesProgram[F]) extends Http4sDsl[F] {
         }
         .handleErrorWith {
           case decodingFailure: DecodingFailure =>
-            // Extract field-specific error messages
-            val errorMessage = extractFieldError(decodingFailure)
-            BadRequest(ErrorResponse(errorMessage))
+            BadRequest(ErrorResponse(extractFieldError(decodingFailure)))
           case parseFailure: ParseFailure =>
-            BadRequest(
-              ErrorResponse(s"Invalid request: ${parseFailure.message}")
-            )
+            BadRequest(ErrorResponse(s"Invalid request: ${parseFailure.message}"))
+          case messageFailure: MessageFailure =>
+            val cause = messageFailure.cause
+            val errorMessage = cause match {
+              case Some(df: DecodingFailure) => extractFieldError(df)
+              case _                         => s"Invalid request: ${messageFailure.message}"
+            }
+            BadRequest(ErrorResponse(errorMessage))
           case throwable: Throwable =>
-            BadRequest(
-              ErrorResponse(s"Invalid request body: ${throwable.getMessage}")
-            )
+            BadRequest(ErrorResponse(s"Invalid request body: ${throwable.getMessage}"))
         }
   }
 
+  // Map program errors to HTTP responses
   private def mapProgramError(
       error: forex.programs.rates.errors.Error
   ): F[org.http4s.Response[F]] = {

--- a/forex-mtl/src/main/scala/forex/http/rates/RatesHttpRoutes.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/RatesHttpRoutes.scala
@@ -2,9 +2,9 @@ package forex.http
 package rates
 
 import cats.effect.Sync
-import cats.syntax.flatMap._
+import cats.syntax.all._
 import forex.programs.RatesProgram
-import forex.programs.rates.{ Protocol => RatesProgramProtocol }
+import forex.programs.rates.{Protocol => RatesProgramProtocol}
 import org.http4s.HttpRoutes
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.Router
@@ -16,10 +16,29 @@ class RatesHttpRoutes[F[_]: Sync](rates: RatesProgram[F]) extends Http4sDsl[F] {
   private[http] val prefixPath = "/rates"
 
   private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] {
+    // GET /rates?from=USD&to=EUR
     case GET -> Root :? FromQueryParam(from) +& ToQueryParam(to) =>
-      rates.get(RatesProgramProtocol.GetRatesRequest(from, to)).flatMap(Sync[F].fromEither).flatMap { rate =>
-        Ok(rate.asGetApiResponse)
-      }
+      rates
+        .get(RatesProgramProtocol.GetRatesRequest(from, to))
+        .flatMap(Sync[F].fromEither)
+        .flatMap { rate =>
+          Ok(rate.asGetApiResponse)
+        }
+
+    // POST /rates
+    case req @ POST -> Root =>
+      for {
+        request <- req.as[PostApiRequest]
+        result <- rates.compare(
+          RatesProgramProtocol.CompareRatesRequest(
+            request.from,
+            request.to,
+            request.amount
+          )
+        )
+        resp <- Sync[F].fromEither(result)
+        ok <- Ok(resp.asPostApiResponse(request.amount))
+      } yield ok
   }
 
   val routes: HttpRoutes[F] = Router(

--- a/forex-mtl/src/main/scala/forex/http/rates/RatesHttpRoutes.scala
+++ b/forex-mtl/src/main/scala/forex/http/rates/RatesHttpRoutes.scala
@@ -3,42 +3,152 @@ package rates
 
 import cats.effect.Sync
 import cats.syntax.all._
+import forex.domain.Currency
 import forex.programs.RatesProgram
 import forex.programs.rates.{Protocol => RatesProgramProtocol}
 import org.http4s.HttpRoutes
 import org.http4s.dsl.Http4sDsl
 import org.http4s.server.Router
+import org.http4s.ParseFailure
+import io.circe.{DecodingFailure, CursorOp}
 
 class RatesHttpRoutes[F[_]: Sync](rates: RatesProgram[F]) extends Http4sDsl[F] {
 
-  import Converters._, QueryParams._, Protocol._
+  import Converters._, Protocol._
 
   private[http] val prefixPath = "/rates"
 
   private val httpRoutes: HttpRoutes[F] = HttpRoutes.of[F] {
     // GET /rates?from=USD&to=EUR
-    case GET -> Root :? FromQueryParam(from) +& ToQueryParam(to) =>
-      rates
-        .get(RatesProgramProtocol.GetRatesRequest(from, to))
-        .flatMap(Sync[F].fromEither)
-        .flatMap { rate =>
-          Ok(rate.asGetApiResponse)
+    case req @ GET -> Root =>
+      val queryParams = req.uri.multiParams
+      val errors = scala.collection.mutable.ListBuffer[String]()
+
+      // Parse 'from' parameter
+      val fromOpt =
+        queryParams.get("from").flatMap(_.headOption).flatMap { fromStr =>
+          scala.util
+            .Try(Currency.fromString(fromStr))
+            .toOption
+            .map(_ -> fromStr)
         }
+
+      // Parse 'to' parameter
+      val toOpt = queryParams.get("to").flatMap(_.headOption).flatMap { toStr =>
+        scala.util.Try(Currency.fromString(toStr)).toOption.map(_ -> toStr)
+      }
+
+      // Validate 'from' parameter
+      queryParams.get("from") match {
+        case Some(values) if values.nonEmpty =>
+          val fromValue = values.head
+          if (fromOpt.isEmpty) {
+            errors += s"Invalid 'from' currency: '$fromValue'. Must be one of: AUD, CAD, CHF, EUR, GBP, NZD, JPY, SGD, USD"
+          }
+        case _ => errors += "Missing required query parameter: 'from'"
+      }
+
+      // Validate 'to' parameter
+      queryParams.get("to") match {
+        case Some(values) if values.nonEmpty =>
+          val toValue = values.head
+          if (toOpt.isEmpty) {
+            errors += s"Invalid 'to' currency: '$toValue'. Must be one of: AUD, CAD, CHF, EUR, GBP, NZD, JPY, SGD, USD"
+          }
+        case _ => errors += "Missing required query parameter: 'to'"
+      }
+
+      // If there are validation errors, return BadRequest
+      if (errors.nonEmpty) {
+        BadRequest(ErrorResponse(errors.mkString("; ")))
+      } else {
+        // Both parameters are valid, proceed with the request
+        (fromOpt, toOpt) match {
+          case (Some((from, _)), Some((to, _))) =>
+            rates
+              .get(RatesProgramProtocol.GetRatesRequest(from, to))
+              .flatMap {
+                case Right(rate) => Ok(rate.asGetApiResponse)
+                case Left(error) => mapProgramError(error)
+              }
+          case _ =>
+            BadRequest(
+              ErrorResponse(
+                "Missing required query parameters. Both 'from' and 'to' parameters are required. " +
+                  "Example: /rates?from=USD&to=EUR"
+              )
+            )
+        }
+      }
 
     // POST /rates
     case req @ POST -> Root =>
-      for {
-        request <- req.as[PostApiRequest]
-        result <- rates.compare(
-          RatesProgramProtocol.CompareRatesRequest(
-            request.from,
-            request.to,
-            request.amount
-          )
+      req
+        .as[PostApiRequest]
+        .flatMap { request =>
+          rates
+            .compare(
+              RatesProgramProtocol.CompareRatesRequest(
+                request.from,
+                request.to,
+                request.amount
+              )
+            )
+            .flatMap {
+              case Right(rate) => Ok(rate.asPostApiResponse(request.amount))
+              case Left(error) => mapProgramError(error)
+            }
+        }
+        .handleErrorWith {
+          case decodingFailure: DecodingFailure =>
+            // Extract field-specific error messages
+            val errorMessage = extractFieldError(decodingFailure)
+            BadRequest(ErrorResponse(errorMessage))
+          case parseFailure: ParseFailure =>
+            BadRequest(
+              ErrorResponse(s"Invalid request: ${parseFailure.message}")
+            )
+          case throwable: Throwable =>
+            BadRequest(
+              ErrorResponse(s"Invalid request body: ${throwable.getMessage}")
+            )
+        }
+  }
+
+  private def mapProgramError(
+      error: forex.programs.rates.errors.Error
+  ): F[org.http4s.Response[F]] = {
+    import forex.programs.rates.errors.Error._
+    error match {
+      case RateLookupFailed(msg) =>
+        BadGateway(ErrorResponse(s"Upstream service error: $msg"))
+      case RateStale(msg) =>
+        ServiceUnavailable(
+          ErrorResponse(s"Rate is currently unavailable: $msg")
         )
-        resp <- Sync[F].fromEither(result)
-        ok <- Ok(resp.asPostApiResponse(request.amount))
-      } yield ok
+      case _ =>
+        InternalServerError(ErrorResponse("An unexpected error occurred"))
+    }
+  }
+
+  // Helper method to extract field-specific error messages from DecodingFailure
+  private def extractFieldError(failure: DecodingFailure): String = {
+    val fieldPath = failure.history
+      .collectFirst { case CursorOp.DownField(field) =>
+        field
+      }
+      .getOrElse("unknown")
+
+    failure.message match {
+      case msg if msg.contains("Invalid currency") =>
+        s"Invalid field '$fieldPath': $msg. Must be one of: AUD, CAD, CHF, EUR, GBP, NZD, JPY, SGD, USD"
+      case msg if msg.contains("amount") || msg.contains("Field 'amount'") =>
+        msg
+      case msg if msg.contains("Missing") =>
+        s"Missing required field: '$fieldPath'"
+      case msg =>
+        s"Invalid field '$fieldPath': $msg"
+    }
   }
 
   val routes: HttpRoutes[F] = Router(

--- a/forex-mtl/src/main/scala/forex/programs/rates/Algebra.scala
+++ b/forex-mtl/src/main/scala/forex/programs/rates/Algebra.scala
@@ -5,4 +5,5 @@ import errors._
 
 trait Algebra[F[_]] {
   def get(request: Protocol.GetRatesRequest): F[Error Either Rate]
+  def compare(request: Protocol.CompareRatesRequest): F[Error Either Rate]
 }

--- a/forex-mtl/src/main/scala/forex/programs/rates/Program.scala
+++ b/forex-mtl/src/main/scala/forex/programs/rates/Program.scala
@@ -13,6 +13,9 @@ class Program[F[_]: Functor](
   override def get(request: Protocol.GetRatesRequest): F[Error Either Rate] =
     EitherT(ratesService.get(Rate.Pair(request.from, request.to))).leftMap(toProgramError(_)).value
 
+  override def compare(request: Protocol.CompareRatesRequest): F[Error Either Rate] =
+    EitherT(ratesService.get(Rate.Pair(request.from, request.to))).leftMap(toProgramError(_)).value
+
 }
 
 object Program {

--- a/forex-mtl/src/main/scala/forex/programs/rates/Protocol.scala
+++ b/forex-mtl/src/main/scala/forex/programs/rates/Protocol.scala
@@ -9,4 +9,10 @@ object Protocol {
       to: Currency
   )
 
+  final case class CompareRatesRequest(
+      from: Currency,
+      to: Currency,
+      amount: BigDecimal
+  )
+
 }

--- a/forex-mtl/src/main/scala/forex/programs/rates/errors.scala
+++ b/forex-mtl/src/main/scala/forex/programs/rates/errors.scala
@@ -4,13 +4,20 @@ import forex.services.rates.errors.{ Error => RatesServiceError }
 
 object errors {
 
-  sealed trait Error extends Exception
+  sealed trait Error extends Exception {
+    def getMessage: String
+  }
   object Error {
-    final case class RateLookupFailed(msg: String) extends Error
+    final case class RateLookupFailed(msg: String) extends Error {
+      override def getMessage: String = msg
+    }
+    final case class RateStale(msg: String) extends Error {
+      override def getMessage: String = msg
+    }
   }
 
   def toProgramError(error: RatesServiceError): Error = error match {
     case RatesServiceError.OneFrameLookupFailed(msg) => Error.RateLookupFailed(msg)
-    case RatesServiceError.RateStale(msg) => Error.RateLookupFailed(msg)
+    case RatesServiceError.RateStale(msg) => Error.RateStale(msg)
   }
 }

--- a/forex-mtl/src/main/scala/forex/programs/rates/errors.scala
+++ b/forex-mtl/src/main/scala/forex/programs/rates/errors.scala
@@ -11,5 +11,6 @@ object errors {
 
   def toProgramError(error: RatesServiceError): Error = error match {
     case RatesServiceError.OneFrameLookupFailed(msg) => Error.RateLookupFailed(msg)
+    case RatesServiceError.RateStale(msg) => Error.RateLookupFailed(msg)
   }
 }

--- a/forex-mtl/src/main/scala/forex/services/cache/InMemoryCache.scala
+++ b/forex-mtl/src/main/scala/forex/services/cache/InMemoryCache.scala
@@ -1,0 +1,50 @@
+package forex.services.cache
+
+import cats.effect.Sync
+import cats.syntax.all._
+import forex.domain.Rate
+import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.ConcurrentHashMap
+
+class InMemoryCache[F[_]: Sync] private (
+    cache: ConcurrentHashMap[Rate.Pair, CacheEntry]
+) extends Algebra[F] {
+
+  override def get(pair: Rate.Pair): F[Option[Rate]] = {
+    val currentTime = System.currentTimeMillis()
+    val entry = Option(cache.get(pair))
+    val validEntry = entry.filter(_.isValid(currentTime))
+    
+    // Remove expired entries
+    if (entry.isDefined && validEntry.isEmpty) {
+      cache.remove(pair)
+    }
+    
+    Sync[F].pure(validEntry.map(_.rate))
+  }
+
+  override def put(pair: Rate.Pair, rate: Rate, ttl: FiniteDuration): F[Unit] = {
+    val currentTime = System.currentTimeMillis()
+    val expiresAt = currentTime + ttl.toMillis
+    cache.put(pair, CacheEntry(rate, expiresAt))
+    Sync[F].pure(())
+  }
+
+  override def remove(pair: Rate.Pair): F[Unit] = {
+    Sync[F].delay(cache.remove(pair)).void
+  }
+
+  override def clear(): F[Unit] = {
+    Sync[F].delay(cache.clear()).void
+  }
+}
+
+object InMemoryCache {
+  def apply[F[_]: Sync]: F[Algebra[F]] = {
+    Sync[F].delay(new ConcurrentHashMap[Rate.Pair, CacheEntry]()).map(new InMemoryCache[F](_))
+  }
+}
+
+private case class CacheEntry(rate: Rate, expiresAt: Long) {
+  def isValid(currentTime: Long): Boolean = currentTime < expiresAt
+}

--- a/forex-mtl/src/main/scala/forex/services/cache/algebra.scala
+++ b/forex-mtl/src/main/scala/forex/services/cache/algebra.scala
@@ -1,0 +1,11 @@
+package forex.services.cache
+
+import forex.domain.Rate
+import scala.concurrent.duration.FiniteDuration
+
+trait Algebra[F[_]] {
+  def get(pair: Rate.Pair): F[Option[Rate]]
+  def put(pair: Rate.Pair, rate: Rate, ttl: FiniteDuration): F[Unit]
+  def remove(pair: Rate.Pair): F[Unit]
+  def clear(): F[Unit]
+}

--- a/forex-mtl/src/main/scala/forex/services/cache/package.scala
+++ b/forex-mtl/src/main/scala/forex/services/cache/package.scala
@@ -1,0 +1,11 @@
+package forex.services
+
+import cats.effect.Sync
+
+package object cache {
+  type CacheService[F[_]] = forex.services.cache.Algebra[F]
+
+  object CacheService {
+    def apply[F[_]: Sync]: F[CacheService[F]] = InMemoryCache[F]
+  }
+}

--- a/forex-mtl/src/main/scala/forex/services/rates/Interpreters.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/Interpreters.scala
@@ -3,6 +3,15 @@ package forex.services.rates
 import cats.Applicative
 import interpreters._
 
+import forex.config.ApplicationConfig
+import org.http4s.client.Client
+
 object Interpreters {
+  // TODO: replace dummy data with live Oneframe data
   def dummy[F[_]: Applicative]: Algebra[F] = new OneFrameDummy[F]()
+  def live[F[_]: Applicative](config: ApplicationConfig, client: Client[F]): Algebra[F] = {
+    val _ = config
+    val _ = client
+    new OneFrameDummy[F]()
+  }
 }

--- a/forex-mtl/src/main/scala/forex/services/rates/Interpreters.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/Interpreters.scala
@@ -1,17 +1,14 @@
 package forex.services.rates
 
 import cats.Applicative
+import cats.effect.Sync
 import interpreters._
 
 import forex.config.ApplicationConfig
 import org.http4s.client.Client
 
 object Interpreters {
-  // TODO: replace dummy data with live Oneframe data
   def dummy[F[_]: Applicative]: Algebra[F] = new OneFrameDummy[F]()
-  def live[F[_]: Applicative](config: ApplicationConfig, client: Client[F]): Algebra[F] = {
-    val _ = config
-    val _ = client
-    new OneFrameDummy[F]()
-  }
+  def live[F[_]: Sync](config: ApplicationConfig, client: Client[F]): Algebra[F] = 
+    new OneFrameLive[F](config, client)
 }

--- a/forex-mtl/src/main/scala/forex/services/rates/Interpreters.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/Interpreters.scala
@@ -5,10 +5,14 @@ import cats.effect.Sync
 import interpreters._
 
 import forex.config.ApplicationConfig
+import forex.services.cache.CacheService
 import org.http4s.client.Client
 
 object Interpreters {
+  // Defaut dummy data for testing
   def dummy[F[_]: Applicative]: Algebra[F] = new OneFrameDummy[F]()
-  def live[F[_]: Sync](config: ApplicationConfig, client: Client[F]): Algebra[F] = 
-    new OneFrameLive[F](config, client)
+
+  // Live data from OneFrame service
+  def live[F[_]: Sync](config: ApplicationConfig, client: Client[F], cache: CacheService[F]): Algebra[F] = 
+    new OneFrameLive[F](config, client, cache)
 }

--- a/forex-mtl/src/main/scala/forex/services/rates/errors.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/errors.scala
@@ -5,6 +5,7 @@ object errors {
   sealed trait Error
   object Error {
     final case class OneFrameLookupFailed(msg: String) extends Error
+    final case class RateStale(msg: String) extends Error
   }
 
 }

--- a/forex-mtl/src/main/scala/forex/services/rates/interpreters/OneFrameDummy.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/interpreters/OneFrameDummy.scala
@@ -4,12 +4,18 @@ import forex.services.rates.Algebra
 import cats.Applicative
 import cats.syntax.applicative._
 import cats.syntax.either._
-import forex.domain.{ Price, Rate, Timestamp }
+import forex.domain.{Price, Rate, Timestamp}
 import forex.services.rates.errors._
 
 class OneFrameDummy[F[_]: Applicative] extends Algebra[F] {
 
   override def get(pair: Rate.Pair): F[Error Either Rate] =
-    Rate(pair, Price(BigDecimal(200)), Timestamp.now).asRight[Error].pure[F]
+    Rate(
+      pair,
+      Price(BigDecimal(100)),
+      Price(BigDecimal(100)),
+      Price(BigDecimal(100)),
+      Timestamp.now
+    ).asRight[Error].pure[F]
 
 }

--- a/forex-mtl/src/main/scala/forex/services/rates/interpreters/OneFrameDummy.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/interpreters/OneFrameDummy.scala
@@ -10,6 +10,6 @@ import forex.services.rates.errors._
 class OneFrameDummy[F[_]: Applicative] extends Algebra[F] {
 
   override def get(pair: Rate.Pair): F[Error Either Rate] =
-    Rate(pair, Price(BigDecimal(100)), Timestamp.now).asRight[Error].pure[F]
+    Rate(pair, Price(BigDecimal(200)), Timestamp.now).asRight[Error].pure[F]
 
 }

--- a/forex-mtl/src/main/scala/forex/services/rates/interpreters/OneFrameLive.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/interpreters/OneFrameLive.scala
@@ -1,0 +1,83 @@
+package forex.services.rates.interpreters
+
+import forex.services.rates.Algebra
+import forex.domain._
+import forex.services.rates.errors.{ Error => RateError }
+import forex.config.ApplicationConfig
+import cats.effect.Sync
+import cats.syntax.all._
+import org.http4s._
+import org.http4s.client.Client
+import org.http4s.circe.jsonOf
+import org.http4s.Method.GET
+import org.typelevel.ci.CIString
+import io.circe._
+import io.circe.generic.semiauto._
+import java.time.{OffsetDateTime, LocalDateTime, ZoneOffset}
+
+class OneFrameLive[F[_]: Sync](
+    config: ApplicationConfig,
+    client: Client[F]
+) extends Algebra[F] {
+
+  import OneFrameLive._
+
+  override def get(pair: Rate.Pair): F[RateError Either Rate] = {
+    val uriResult = Uri.fromString(s"${config.oneFrame.baseUrl}/rates")
+      .map(_.withQueryParam("pair", s"${pair.from}${pair.to}"))
+
+    uriResult match {
+      case Left(e) =>
+        (RateError.OneFrameLookupFailed(s"Invalid URI: $e"): RateError).asLeft[Rate].pure[F]
+      case Right(uri) =>
+        val request = Request[F](GET, uri)
+          .withHeaders(Header.Raw(CIString("token"), config.oneFrame.token))
+
+        client.run(request).use { response =>
+          if (response.status.isSuccess) {
+            response.as[List[OneFrameRate]].map { rates =>
+              rates.find(r => r.from == pair.from && r.to == pair.to) match {
+                case Some(rate) =>
+                  Rate(pair, rate.price, Timestamp(rate.time_stamp)).asRight[RateError]
+                case None =>
+                  (RateError.OneFrameLookupFailed("Rate not found in response"): RateError).asLeft[Rate]
+              }
+            }
+          } else {
+            (RateError.OneFrameLookupFailed(s"Upstream returned status: ${response.status}"): RateError).asLeft[Rate].pure[F]
+          }
+        }.handleError { e =>
+          (RateError.OneFrameLookupFailed(s"Request failed: ${e.getMessage}"): RateError).asLeft[Rate]
+        }
+    }
+  }
+}
+
+object OneFrameLive {
+  case class OneFrameRate(
+      from: Currency,
+      to: Currency,
+      bid: BigDecimal,
+      ask: BigDecimal,
+      price: Price,
+      time_stamp: OffsetDateTime
+  )
+
+  object OneFrameRate {
+    implicit val currencyDecoder: Decoder[Currency] = Decoder.decodeString.emap { s =>
+       Either.catchNonFatal(Currency.fromString(s)).leftMap(_ => s"Invalid currency: $s")
+    }
+
+    implicit val priceDecoder: Decoder[Price] = Decoder.decodeBigDecimal.map(Price(_))
+
+    implicit val timestampDecoder: Decoder[OffsetDateTime] = Decoder.decodeString.emap { str =>
+      Either.catchNonFatal(OffsetDateTime.parse(str))
+        .orElse(Either.catchNonFatal(LocalDateTime.parse(str).atOffset(ZoneOffset.UTC)))
+        .leftMap(_ => s"Failed to parse timestamp: $str")
+    }
+
+    implicit val decoder: Decoder[OneFrameRate] = deriveDecoder[OneFrameRate]
+  }
+  
+  implicit def entityDecoder[F[_]: Sync]: EntityDecoder[F, List[OneFrameRate]] = jsonOf[F, List[OneFrameRate]]
+}

--- a/forex-mtl/src/main/scala/forex/services/rates/interpreters/OneFrameLive.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/interpreters/OneFrameLive.scala
@@ -4,6 +4,7 @@ import forex.services.rates.Algebra
 import forex.domain._
 import forex.services.rates.errors.{ Error => RateError }
 import forex.config.ApplicationConfig
+import forex.services.cache.CacheService
 import cats.effect.Sync
 import cats.syntax.all._
 import org.http4s._
@@ -13,16 +14,35 @@ import org.http4s.Method.GET
 import org.typelevel.ci.CIString
 import io.circe._
 import io.circe.generic.semiauto._
-import java.time.{OffsetDateTime, LocalDateTime, ZoneOffset}
+import java.time.{OffsetDateTime, LocalDateTime, ZoneOffset, Instant}
+import java.time.temporal.ChronoUnit
 
 class OneFrameLive[F[_]: Sync](
     config: ApplicationConfig,
-    client: Client[F]
+    client: Client[F],
+    cache: CacheService[F]
 ) extends Algebra[F] {
 
   import OneFrameLive._
 
   override def get(pair: Rate.Pair): F[RateError Either Rate] = {
+    // First check cache
+    cache.get(pair).flatMap {
+      case Some(cachedRate) =>
+        // Validate freshness
+        if (isRateFresh(cachedRate)) {
+          Sync[F].pure(cachedRate.asRight[RateError])
+        } else {
+          // Remove stale rate from cache and fetch fresh
+          cache.remove(pair) >> fetchAndCacheRate(pair)
+        }
+      case None =>
+        // Cache miss - fetch from One-Frame
+        fetchAndCacheRate(pair)
+    }
+  }
+
+  private def fetchAndCacheRate(pair: Rate.Pair): F[RateError Either Rate] = {
     val uriResult = Uri.fromString(s"${config.oneFrame.baseUrl}/rates")
       .map(_.withQueryParam("pair", s"${pair.from}${pair.to}"))
 
@@ -35,27 +55,37 @@ class OneFrameLive[F[_]: Sync](
 
         client.run(request).use { response =>
           if (response.status.isSuccess) {
-            response.as[List[OneFrameRate]].map { rates =>
-              rates.find(r => r.from == pair.from && r.to == pair.to) match {
+            for {
+              rates <- response.as[List[OneFrameRate]]
+              result <- rates.find(r => r.from == pair.from && r.to == pair.to) match {
                 case Some(rate) =>
-                  Rate(
+                  val domainRate = Rate(
                     pair,
                     rate.price,
                     Price(rate.bid),
                     Price(rate.ask),
                     Timestamp(rate.time_stamp)
-                  ).asRight[RateError]
+                  )
+                  // Cache the rate and return
+                  cache.put(pair, domainRate, config.oneFrame.ttl).as(domainRate.asRight[RateError])
                 case None =>
-                  (RateError.OneFrameLookupFailed("Rate not found in response"): RateError).asLeft[Rate]
+                  Sync[F].pure((RateError.OneFrameLookupFailed("Rate not found in response"): RateError).asLeft[Rate])
               }
-            }
+            } yield result
           } else {
-            (RateError.OneFrameLookupFailed(s"Upstream returned status: ${response.status}"): RateError).asLeft[Rate].pure[F]
+            Sync[F].pure((RateError.OneFrameLookupFailed(s"Upstream returned status: ${response.status}"): RateError).asLeft[Rate])
           }
         }.handleError { e =>
           (RateError.OneFrameLookupFailed(s"Request failed: ${e.getMessage}"): RateError).asLeft[Rate]
         }
     }
+  }
+
+  private def isRateFresh(rate: Rate): Boolean = {
+    val now = Instant.now()
+    val rateTime = rate.timestamp.value.toInstant
+    val minutesDiff = ChronoUnit.MINUTES.between(rateTime, now)
+    minutesDiff <= config.oneFrame.ttl.toMinutes
   }
 }
 

--- a/forex-mtl/src/main/scala/forex/services/rates/interpreters/OneFrameLive.scala
+++ b/forex-mtl/src/main/scala/forex/services/rates/interpreters/OneFrameLive.scala
@@ -38,7 +38,13 @@ class OneFrameLive[F[_]: Sync](
             response.as[List[OneFrameRate]].map { rates =>
               rates.find(r => r.from == pair.from && r.to == pair.to) match {
                 case Some(rate) =>
-                  Rate(pair, rate.price, Timestamp(rate.time_stamp)).asRight[RateError]
+                  Rate(
+                    pair,
+                    rate.price,
+                    Price(rate.bid),
+                    Price(rate.ask),
+                    Timestamp(rate.time_stamp)
+                  ).asRight[RateError]
                 case None =>
                   (RateError.OneFrameLookupFailed("Rate not found in response"): RateError).asLeft[Rate]
               }

--- a/forex-mtl/src/test/scala/forex/services/cache/InMemoryCacheSpec.scala
+++ b/forex-mtl/src/test/scala/forex/services/cache/InMemoryCacheSpec.scala
@@ -1,0 +1,74 @@
+package forex.services.cache
+
+import cats.effect.IO
+import forex.domain._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scala.concurrent.duration._
+import java.time.OffsetDateTime
+
+class InMemoryCacheSpec extends AnyFlatSpec with Matchers {
+
+  "InMemoryCache" should "store and retrieve rates" in {
+    val cache = InMemoryCache[IO].unsafeRunSync()
+    val pair = Rate.Pair(Currency.USD, Currency.JPY)
+    val rate = Rate(
+      pair,
+      Price(BigDecimal("0.71")),
+      Price(BigDecimal("0.61")),
+      Price(BigDecimal("0.82")),
+      Timestamp(OffsetDateTime.now())
+    )
+
+    // Store rate
+    cache.put(pair, rate, 5.minutes).unsafeRunSync()
+    
+    // Retrieve rate
+    val retrieved = cache.get(pair).unsafeRunSync()
+    retrieved shouldBe Some(rate)
+  }
+
+  it should "return None for expired rates" in {
+    val cache = InMemoryCache[IO].unsafeRunSync()
+    val pair = Rate.Pair(Currency.USD, Currency.JPY)
+    val rate = Rate(
+      pair,
+      Price(BigDecimal(0.71)),
+      Price(BigDecimal(0.61)),
+      Price(BigDecimal(0.82)),
+      Timestamp(OffsetDateTime.now().minusMinutes(10))
+    )
+
+    // Store rate with 1ms TTL (expired immediately)
+    cache.put(pair, rate, 1.millis).unsafeRunSync()
+    
+    // Wait a bit to ensure expiration
+    Thread.sleep(10)
+    
+    // Retrieve rate - should be None due to expiration
+    val retrieved = cache.get(pair).unsafeRunSync()
+    retrieved shouldBe None
+  }
+
+  it should "remove rates" in {
+    val cache = InMemoryCache[IO].unsafeRunSync()
+    val pair = Rate.Pair(Currency.USD, Currency.JPY)
+    val rate = Rate(
+      pair,
+      Price(BigDecimal(0.71)),
+      Price(BigDecimal(0.61)),
+      Price(BigDecimal(0.82)),
+      Timestamp(OffsetDateTime.now())
+    )
+
+    // Store rate
+    cache.put(pair, rate, 5.minutes).unsafeRunSync()
+    
+    // Remove rate
+    cache.remove(pair).unsafeRunSync()
+    
+    // Retrieve rate - should be None
+    val retrieved = cache.get(pair).unsafeRunSync()
+    retrieved shouldBe None
+  }
+}

--- a/forex-mtl/src/test/scala/forex/services/rates/interpreters/OneFrameLiveSpec.scala
+++ b/forex-mtl/src/test/scala/forex/services/rates/interpreters/OneFrameLiveSpec.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import forex.config._
 import forex.domain._
 import forex.services.rates.errors.Error
+import forex.services.cache.CacheService
 import org.http4s._
 import org.http4s.client.Client
 import org.scalatest.flatspec.AnyFlatSpec
@@ -19,7 +20,7 @@ class OneFrameLiveSpec extends AnyFlatSpec with Matchers {
   val config = ConfigSource.default.at("app").load[ApplicationConfig].getOrElse(
     ApplicationConfig(
       HttpConfig("localhost", 8080, 40.seconds),
-      OneFrameConfig("http://localhost:8080", "token")
+      OneFrameConfig("http://localhost:8080", "token", 5.minutes)
     )
   )
 
@@ -41,7 +42,8 @@ class OneFrameLiveSpec extends AnyFlatSpec with Matchers {
       case _ => IO.pure(Response[IO](Status.Ok).withEntity(sampleJson))
     }.orNotFound)
 
-    val interpreter = new OneFrameLive[IO](config, client)
+    val cache = CacheService[IO].unsafeRunSync()
+    val interpreter = new OneFrameLive[IO](config, client, cache)
     val pair = Rate.Pair(Currency.USD, Currency.JPY)
 
     val result = interpreter.get(pair).unsafeRunSync()
@@ -60,7 +62,8 @@ class OneFrameLiveSpec extends AnyFlatSpec with Matchers {
       case _ => IO.pure(Response[IO](Status.Ok).withEntity(sampleJson))
     }.orNotFound)
 
-    val interpreter = new OneFrameLive[IO](config, client)
+    val cache = CacheService[IO].unsafeRunSync()
+    val interpreter = new OneFrameLive[IO](config, client, cache)
     val pair = Rate.Pair(Currency.EUR, Currency.USD) // Mismatch
 
     val result = interpreter.get(pair).unsafeRunSync()
@@ -73,7 +76,8 @@ class OneFrameLiveSpec extends AnyFlatSpec with Matchers {
       case _ => IO.pure(Response[IO](Status.Ok).withEntity("invalid json"))
     }.orNotFound)
 
-    val interpreter = new OneFrameLive[IO](config, client)
+    val cache = CacheService[IO].unsafeRunSync()
+    val interpreter = new OneFrameLive[IO](config, client, cache)
     val pair = Rate.Pair(Currency.USD, Currency.JPY)
 
     val result = interpreter.get(pair).unsafeRunSync()

--- a/forex-mtl/src/test/scala/forex/services/rates/interpreters/OneFrameLiveSpec.scala
+++ b/forex-mtl/src/test/scala/forex/services/rates/interpreters/OneFrameLiveSpec.scala
@@ -1,0 +1,83 @@
+package forex.services.rates.interpreters
+
+import cats.effect.IO
+import forex.config._
+import forex.domain._
+import forex.services.rates.errors.Error
+import org.http4s._
+import org.http4s.client.Client
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scala.concurrent.duration._
+import java.time.OffsetDateTime
+
+import pureconfig.ConfigSource
+import pureconfig.generic.auto._
+
+class OneFrameLiveSpec extends AnyFlatSpec with Matchers {
+
+  val config = ConfigSource.default.at("app").load[ApplicationConfig].getOrElse(
+    ApplicationConfig(
+      HttpConfig("localhost", 8080, 40.seconds),
+      OneFrameConfig("http://localhost:8080", "token")
+    )
+  )
+
+  val sampleJson = """
+    [
+      {
+        "from": "USD",
+        "to": "JPY",
+        "bid": 0.61,
+        "ask": 0.82,
+        "price": 0.71,
+        "time_stamp": "2019-01-01T00:00:00.000"
+      }
+    ]
+  """
+
+  "OneFrameLive" should "correctly adapt valid response to domain Rate" in {
+    val client = Client.fromHttpApp[IO](HttpRoutes.of[IO] {
+      case _ => IO.pure(Response[IO](Status.Ok).withEntity(sampleJson))
+    }.orNotFound)
+
+    val interpreter = new OneFrameLive[IO](config, client)
+    val pair = Rate.Pair(Currency.USD, Currency.JPY)
+
+    val result = interpreter.get(pair).unsafeRunSync()
+
+    result should matchPattern { case Right(_) => }
+    val rate = result.toOption.get
+    rate.pair shouldBe pair
+    rate.price shouldBe Price(BigDecimal(0.71))
+    rate.bid shouldBe Price(BigDecimal(0.61))
+    rate.ask shouldBe Price(BigDecimal(0.82))
+    rate.timestamp.value shouldBe OffsetDateTime.parse("2019-01-01T00:00:00Z")
+  }
+
+  it should "return OneFrameLookupFailed when pair does not match" in {
+    val client = Client.fromHttpApp[IO](HttpRoutes.of[IO] {
+      case _ => IO.pure(Response[IO](Status.Ok).withEntity(sampleJson))
+    }.orNotFound)
+
+    val interpreter = new OneFrameLive[IO](config, client)
+    val pair = Rate.Pair(Currency.EUR, Currency.USD) // Mismatch
+
+    val result = interpreter.get(pair).unsafeRunSync()
+
+    result should matchPattern { case Left(Error.OneFrameLookupFailed("Rate not found in response")) => }
+  }
+
+  it should "handle invalid JSON gracefully" in {
+    val client = Client.fromHttpApp[IO](HttpRoutes.of[IO] {
+      case _ => IO.pure(Response[IO](Status.Ok).withEntity("invalid json"))
+    }.orNotFound)
+
+    val interpreter = new OneFrameLive[IO](config, client)
+    val pair = Rate.Pair(Currency.USD, Currency.JPY)
+
+    val result = interpreter.get(pair).unsafeRunSync()
+
+    result should matchPattern { case Left(Error.OneFrameLookupFailed(_)) => }
+  }
+}


### PR DESCRIPTION
##  Overview
This PR implements a robust local proxy for the Forex currency exchange rate service. It addresses the 1,000 requests/day limitation of the One-Frame upstream API to support 10,000+ requests/day while maintaining a 5-minute data freshness guarantee.

##  Key Requirements Addressed
- [x] **Currency Support**: Returns exchange rates for 2 supported currencies.
- [x] **Data Freshness with intelligent caching**: Rates are never older than 5 minutes, enforced via TTL validation.
- [x] **High Throughput**: Supports 10,000+ requests/day using a single API token by minimizing calls to the One-Frame API.
- [x]  **Graceful Error Handling**: Validate and handle errors gracefully with clear and descriptive messages for invalid currencies or upstream failures

##  Technical Implementation
- **Caching Layer**: Implemented a thread-safe `InMemoryCache.scala` with TTL support.
- **Freshness Validation**: Integrated logic in `OneFrameLive.scala` to verify timestamps against the 5-minute window.
- **Error Handling**: Added specific error types like `RateStale` and improved descriptive feedback for upstream failures.
- **Configuration**: Unified TTL settings in `application.conf.`

## API Endpoints
- GET: `http://localhost:3000/rates?from=USD&to=JPY`  - for getting currency exchange rates
- POST: `http://localhost:3000/rates` (add-on)  - for users to set the amount they want to convert 
## Testing
- **Unit Tests**: Added unit test for cache and rates interpreter.
- **Manual Test**: Verify via `curl "http://localhost:3000/rates?from=USD&to=JPY"`.